### PR TITLE
added example on how to get en localized app label

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ func main() {
 
 	icon, _ := pkg.Icon(nil) // returns the icon of APK as image.Image
 	pkgName := pkg.PackageName() // returns the package name
+
+	resConfigEN := &androidbinary.ResTableConfig{
+		Language: [2]uint8{uint8('e'), uint8('n')},
+	}
+	appLabel, _ = pkg.Label(resConfigEN) // get app label for en translation
 }
 ```
 


### PR DESCRIPTION
It took me a while to find out how to get the en app label text (or in my case the default app label text) so it would be great if you could merge this to spare time for others.
Thanks!