### PR TITLE
Remove the 'android' namespace from attributes in AndroidManifest.xml

### DIFF
--- a/apk/apkxml.go
+++ b/apk/apkxml.go
@@ -6,20 +6,20 @@ import (
 
 // Instrumentation is an application instrumentation code.
 type Instrumentation struct {
-	Name            androidbinary.String `xml:"http://schemas.android.com/apk/res/android name,attr"`
-	Target          androidbinary.String `xml:"http://schemas.android.com/apk/res/android targetPackage,attr"`
-	HandleProfiling androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android handleProfiling,attr"`
-	FunctionalTest  androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android functionalTest,attr"`
+	Name            androidbinary.String `xml:"name,attr"`
+	Target          androidbinary.String `xml:"targetPackage,attr"`
+	HandleProfiling androidbinary.Bool   `xml:"handleProfiling,attr"`
+	FunctionalTest  androidbinary.Bool   `xml:"functionalTest,attr"`
 }
 
 // ActivityAction is an action of an activity.
 type ActivityAction struct {
-	Name androidbinary.String `xml:"http://schemas.android.com/apk/res/android name,attr"`
+	Name androidbinary.String `xml:"name,attr"`
 }
 
 // ActivityCategory is a category of an activity.
 type ActivityCategory struct {
-	Name androidbinary.String `xml:"http://schemas.android.com/apk/res/android name,attr"`
+	Name androidbinary.String `xml:"name,attr"`
 }
 
 // ActivityIntentFilter is an androidbinary.Int32ent filter of an activity.
@@ -30,56 +30,56 @@ type ActivityIntentFilter struct {
 
 // AppActivity is an activity in an application.
 type AppActivity struct {
-	Theme             androidbinary.String   `xml:"http://schemas.android.com/apk/res/android theme,attr"`
-	Name              androidbinary.String   `xml:"http://schemas.android.com/apk/res/android name,attr"`
-	Label             androidbinary.String   `xml:"http://schemas.android.com/apk/res/android label,attr"`
-	ScreenOrientation androidbinary.String   `xml:"http://schemas.android.com/apk/res/android screenOrientation,attr"`
+	Theme             androidbinary.String   `xml:"theme,attr"`
+	Name              androidbinary.String   `xml:"name,attr"`
+	Label             androidbinary.String   `xml:"label,attr"`
+	ScreenOrientation androidbinary.String   `xml:"screenOrientation,attr"`
 	IntentFilters     []ActivityIntentFilter `xml:"intent-filter"`
 }
 
 // AppActivityAlias https://developer.android.com/guide/topics/manifest/activity-alias-element
 type AppActivityAlias struct {
-	Name           androidbinary.String   `xml:"http://schemas.android.com/apk/res/android name,attr"`
-	Label          androidbinary.String   `xml:"http://schemas.android.com/apk/res/android label,attr"`
-	TargetActivity androidbinary.String   `xml:"http://schemas.android.com/apk/res/android targetActivity,attr"`
+	Name           androidbinary.String   `xml:"name,attr"`
+	Label          androidbinary.String   `xml:"label,attr"`
+	TargetActivity androidbinary.String   `xml:"targetActivity,attr"`
 	IntentFilters  []ActivityIntentFilter `xml:"intent-filter"`
 }
 
 // MetaData is a metadata in an application.
 type MetaData struct {
-	Name  androidbinary.String `xml:"http://schemas.android.com/apk/res/android name,attr"`
-	Value androidbinary.String `xml:"http://schemas.android.com/apk/res/android value,attr"`
+	Name  androidbinary.String `xml:"name,attr"`
+	Value androidbinary.String `xml:"value,attr"`
 }
 
 // Application is an application in an APK.
 type Application struct {
-	AllowTaskReparenting  androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android allowTaskReparenting,attr"`
-	AllowBackup           androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android allowBackup,attr"`
-	BackupAgent           androidbinary.String `xml:"http://schemas.android.com/apk/res/android backupAgent,attr"`
-	Debuggable            androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android debuggable,attr"`
-	Description           androidbinary.String `xml:"http://schemas.android.com/apk/res/android description,attr"`
-	Enabled               androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android enabled,attr"`
-	HasCode               androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android hasCode,attr"`
-	HardwareAccelerated   androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android hardwareAccelerated,attr"`
-	Icon                  androidbinary.String `xml:"http://schemas.android.com/apk/res/android icon,attr"`
-	KillAfterRestore      androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android killAfterRestore,attr"`
-	LargeHeap             androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android largeHeap,attr"`
-	Label                 androidbinary.String `xml:"http://schemas.android.com/apk/res/android label,attr"`
-	Logo                  androidbinary.String `xml:"http://schemas.android.com/apk/res/android logo,attr"`
-	ManageSpaceActivity   androidbinary.String `xml:"http://schemas.android.com/apk/res/android manageSpaceActivity,attr"`
-	Name                  androidbinary.String `xml:"http://schemas.android.com/apk/res/android name,attr"`
-	Permission            androidbinary.String `xml:"http://schemas.android.com/apk/res/android permission,attr"`
-	Persistent            androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android persistent,attr"`
-	Process               androidbinary.String `xml:"http://schemas.android.com/apk/res/android process,attr"`
-	RestoreAnyVersion     androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android restoreAnyVersion,attr"`
-	RequiredAccountType   androidbinary.String `xml:"http://schemas.android.com/apk/res/android requiredAccountType,attr"`
-	RestrictedAccountType androidbinary.String `xml:"http://schemas.android.com/apk/res/android restrictedAccountType,attr"`
-	SupportsRtl           androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android supportsRtl,attr"`
-	TaskAffinity          androidbinary.String `xml:"http://schemas.android.com/apk/res/android taskAffinity,attr"`
-	TestOnly              androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android testOnly,attr"`
-	Theme                 androidbinary.String `xml:"http://schemas.android.com/apk/res/android theme,attr"`
-	UIOptions             androidbinary.String `xml:"http://schemas.android.com/apk/res/android uiOptions,attr"`
-	VMSafeMode            androidbinary.Bool   `xml:"http://schemas.android.com/apk/res/android vmSafeMode,attr"`
+	AllowTaskReparenting  androidbinary.Bool   `xml:"allowTaskReparenting,attr"`
+	AllowBackup           androidbinary.Bool   `xml:"allowBackup,attr"`
+	BackupAgent           androidbinary.String `xml:"backupAgent,attr"`
+	Debuggable            androidbinary.Bool   `xml:"debuggable,attr"`
+	Description           androidbinary.String `xml:"description,attr"`
+	Enabled               androidbinary.Bool   `xml:"enabled,attr"`
+	HasCode               androidbinary.Bool   `xml:"hasCode,attr"`
+	HardwareAccelerated   androidbinary.Bool   `xml:"hardwareAccelerated,attr"`
+	Icon                  androidbinary.String `xml:"icon,attr"`
+	KillAfterRestore      androidbinary.Bool   `xml:"killAfterRestore,attr"`
+	LargeHeap             androidbinary.Bool   `xml:"largeHeap,attr"`
+	Label                 androidbinary.String `xml:"label,attr"`
+	Logo                  androidbinary.String `xml:"logo,attr"`
+	ManageSpaceActivity   androidbinary.String `xml:"manageSpaceActivity,attr"`
+	Name                  androidbinary.String `xml:"name,attr"`
+	Permission            androidbinary.String `xml:"permission,attr"`
+	Persistent            androidbinary.Bool   `xml:"persistent,attr"`
+	Process               androidbinary.String `xml:"process,attr"`
+	RestoreAnyVersion     androidbinary.Bool   `xml:"restoreAnyVersion,attr"`
+	RequiredAccountType   androidbinary.String `xml:"requiredAccountType,attr"`
+	RestrictedAccountType androidbinary.String `xml:"restrictedAccountType,attr"`
+	SupportsRtl           androidbinary.Bool   `xml:"supportsRtl,attr"`
+	TaskAffinity          androidbinary.String `xml:"taskAffinity,attr"`
+	TestOnly              androidbinary.Bool   `xml:"testOnly,attr"`
+	Theme                 androidbinary.String `xml:"theme,attr"`
+	UIOptions             androidbinary.String `xml:"uiOptions,attr"`
+	VMSafeMode            androidbinary.Bool   `xml:"vmSafeMode,attr"`
 	Activities            []AppActivity        `xml:"activity"`
 	ActivityAliases       []AppActivityAlias   `xml:"activity-alias"`
 	MetaData              []MetaData           `xml:"meta-data"`
@@ -87,22 +87,22 @@ type Application struct {
 
 // UsesSDK is target SDK version.
 type UsesSDK struct {
-	Min    androidbinary.Int32 `xml:"http://schemas.android.com/apk/res/android minSdkVersion,attr"`
-	Target androidbinary.Int32 `xml:"http://schemas.android.com/apk/res/android targetSdkVersion,attr"`
-	Max    androidbinary.Int32 `xml:"http://schemas.android.com/apk/res/android maxSdkVersion,attr"`
+	Min    androidbinary.Int32 `xml:"minSdkVersion,attr"`
+	Target androidbinary.Int32 `xml:"targetSdkVersion,attr"`
+	Max    androidbinary.Int32 `xml:"maxSdkVersion,attr"`
 }
 
 // UsesPermission is user grant the system permission.
 type UsesPermission struct {
-	Name androidbinary.String `xml:"http://schemas.android.com/apk/res/android name,attr"`
-	Max  androidbinary.Int32  `xml:"http://schemas.android.com/apk/res/android maxSdkVersion,attr"`
+	Name androidbinary.String `xml:"name,attr"`
+	Max  androidbinary.Int32  `xml:"maxSdkVersion,attr"`
 }
 
 // Manifest is a manifest of an APK.
 type Manifest struct {
 	Package         androidbinary.String `xml:"package,attr"`
-	VersionCode     androidbinary.Int32  `xml:"http://schemas.android.com/apk/res/android versionCode,attr"`
-	VersionName     androidbinary.String `xml:"http://schemas.android.com/apk/res/android versionName,attr"`
+	VersionCode     androidbinary.Int32  `xml:"versionCode,attr"`
+	VersionName     androidbinary.String `xml:"versionName,attr"`
 	App             Application          `xml:"application"`
 	Instrument      Instrumentation      `xml:"instrumentation"`
 	SDK             UsesSDK              `xml:"uses-sdk"`

--- a/example_test.go
+++ b/example_test.go
@@ -25,26 +25,26 @@ func ExampleNewXMLFile() {
 	enc.Encode(v)
 
 	// Output:
-	// 	<Manifest package="net.sorablue.shogo.FWMeasure" xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="テスト版">
-	// 	<application android:allowTaskReparenting="false" android:allowBackup="false" android:backupAgent="" android:debuggable="false" android:description="" android:enabled="false" android:hasCode="false" android:hardwareAccelerated="false" android:icon="@0x7F020000" android:killAfterRestore="false" android:largeHeap="false" android:label="@0x7F040000" android:logo="" android:manageSpaceActivity="" android:name="" android:permission="" android:persistent="false" android:process="" android:restoreAnyVersion="false" android:requiredAccountType="" android:restrictedAccountType="" android:supportsRtl="false" android:taskAffinity="" android:testOnly="false" android:theme="" android:uiOptions="" android:vmSafeMode="false">
-	// 		<activity android:theme="" android:name="FWMeasureActivity" android:label="" android:screenOrientation="0">
+	// <Manifest package="net.sorablue.shogo.FWMeasure" versionCode="1" versionName="テスト版">
+	// 	<application allowTaskReparenting="false" allowBackup="false" backupAgent="" debuggable="false" description="" enabled="false" hasCode="false" hardwareAccelerated="false" icon="@0x7F020000" killAfterRestore="false" largeHeap="false" label="@0x7F040000" logo="" manageSpaceActivity="" name="" permission="" persistent="false" process="" restoreAnyVersion="false" requiredAccountType="" restrictedAccountType="" supportsRtl="false" taskAffinity="" testOnly="false" theme="" uiOptions="" vmSafeMode="false">
+	// 		<activity theme="" name="FWMeasureActivity" label="" screenOrientation="0">
 	// 			<intent-filter>
-	// 				<action android:name="android.intent.action.MAIN"></action>
-	// 				<category android:name="android.intent.category.LAUNCHER"></category>
+	// 				<action name="android.intent.action.MAIN"></action>
+	// 				<category name="android.intent.category.LAUNCHER"></category>
 	// 			</intent-filter>
 	// 		</activity>
-	// 		<activity android:theme="" android:name="MapActivity" android:label="" android:screenOrientation="0"></activity>
-	// 		<activity android:theme="" android:name="SettingActivity" android:label="" android:screenOrientation=""></activity>
-	// 		<activity android:theme="" android:name="PlaceSettingActivity" android:label="" android:screenOrientation=""></activity>
+	// 		<activity theme="" name="MapActivity" label="" screenOrientation="0"></activity>
+	// 		<activity theme="" name="SettingActivity" label="" screenOrientation=""></activity>
+	// 		<activity theme="" name="PlaceSettingActivity" label="" screenOrientation=""></activity>
 	// 	</application>
-	// 	<instrumentation android:name="" android:targetPackage="" android:handleProfiling="false" android:functionalTest="false"></instrumentation>
-	// 	<uses-sdk android:minSdkVersion="0" android:targetSdkVersion="0" android:maxSdkVersion="0"></uses-sdk>
-	// 	<uses-permission android:name="android.permission.CAMERA" android:maxSdkVersion="0"></uses-permission>
-	// 	<uses-permission android:name="android.permission.WAKE_LOCK" android:maxSdkVersion="0"></uses-permission>
-	// 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="0"></uses-permission>
-	// 	<uses-permission android:name="android.permission.INTERNET" android:maxSdkVersion="0"></uses-permission>
-	// 	<uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" android:maxSdkVersion="0"></uses-permission>
-	// 	<uses-permission android:name="android.permission.RECORD_AUDIO" android:maxSdkVersion="0"></uses-permission>
+	// 	<instrumentation name="" targetPackage="" handleProfiling="false" functionalTest="false"></instrumentation>
+	// 	<uses-sdk minSdkVersion="0" targetSdkVersion="0" maxSdkVersion="0"></uses-sdk>
+	// 	<uses-permission name="android.permission.CAMERA" maxSdkVersion="0"></uses-permission>
+	// 	<uses-permission name="android.permission.WAKE_LOCK" maxSdkVersion="0"></uses-permission>
+	// 	<uses-permission name="android.permission.ACCESS_FINE_LOCATION" maxSdkVersion="0"></uses-permission>
+	// 	<uses-permission name="android.permission.INTERNET" maxSdkVersion="0"></uses-permission>
+	// 	<uses-permission name="android.permission.ACCESS_MOCK_LOCATION" maxSdkVersion="0"></uses-permission>
+	// 	<uses-permission name="android.permission.RECORD_AUDIO" maxSdkVersion="0"></uses-permission>
 	// </Manifest>
 }
 


### PR DESCRIPTION
Some apk files contain AndroidManifest.xml,
in which the namespace with value
http://schemas.android.com/apk/res/android
undefined, despite the fact that Android Studio
does not allow you to do this.
Then the manifest is incorrectly parsed.
Therefore, the namespace requirement has been removed.